### PR TITLE
feat: add new example scripts and update logger method signatures

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,39 @@
+name: Pull Request Check
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Debug PR info
+        run: |
+          echo "Base branch: ${{ github.event.pull_request.base.ref }}"
+          echo "Head branch: ${{ github.event.pull_request.head.ref }}"
+          echo "PR number: ${{ github.event.pull_request.number }}"
+
+      - name: Install Dependencies & Build
+        run: |
+          rm -rf ./.npmrc
+          pnpm install
+          pnpm run build
+
+      - name: Test
+        run: pnpm run test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/bin/sh
 lint-staged

--- a/README.md
+++ b/README.md
@@ -154,10 +154,11 @@ logger.scope({ namespace: 'request' }, log => {
 
 ## Raw Write
 
-If you want a "stream-like" write (bypassing level selection but still applying `filter`/`hook`), use `logger.write(...)`.
+If you want a "stream-like" write (bypassing level selection but still applying `filter`/`hook`), use `logger.write(XX)`.
 
 ```typescript
-logger.write('hello', 'world');
+logger.write('hello');
+logger.write('world\n'); // You need to manually add the newline character at the end
 ```
 
 ---
@@ -478,7 +479,7 @@ Log info level messages
 ### `logger.debug(...msg: unknown[])`
 Log debug level messages
 
-### `logger.write(...msg: unknown[])`
+### `logger.write(msg: string)`
 Write output with "raw write" semantics (Node: `stdout.write`, Browser: fallback to `info`)
 
 ### `logger.fork(context: LoggerSubContext)`

--- a/README_CN.md
+++ b/README_CN.md
@@ -151,10 +151,11 @@ logger.scope({ namespace: 'request' }, log => {
 
 ## 直写（Raw Write）
 
-如果你需要更贴近“流式写入”的输出（绕过 level 选择，但仍会执行 `filter`/`hook`），可以使用 `logger.write(...)`。
+如果你需要更贴近“流式写入”的输出（绕过 level 选择，但仍会执行 `filter`/`hook`），可以使用 `logger.write(XX)`。
 
 ```typescript
-logger.write('hello', 'world');
+logger.write('hello');
+logger.write('world\n'); // 需要自行在结尾进行换行符拼接
 ```
 
 ---
@@ -475,7 +476,7 @@ const [cssContent, cssStyle] = Color.wrapColorCSS('Hello', {
 ### `logger.debug(...msg: unknown[])`
 记录调试级别日志
 
-### `logger.write(...msg: unknown[])`
+### `logger.write(msg: string)`
 直写输出（Node：`stdout.write`，Browser：降级为 `info`）
 
 ### `logger.fork(context: LoggerSubContext)`

--- a/examples/table-dir.ts
+++ b/examples/table-dir.ts
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview write / table / dir 示例
+ * @description 演示 logger.write / logger.table / logger.dir 的用法
+ */
+
+import { configure, logger, setLogLevel } from '../src';
+
+configure();
+setLogLevel('debug');
+
+logger.table([
+  { id: 'u-1', name: 'Alice', active: true, score: 98 },
+  { id: 'u-2', name: 'Bob', active: false, score: 72 }
+]);
+
+logger.empty();
+
+logger.dir({
+  user: {
+    id: 'u-1',
+    profile: { email: 'alice@example.com', roles: ['admin'] }
+  },
+  meta: { ts: new Date().toISOString(), deep: { a: 1, b: { c: 2 } } }
+});

--- a/examples/write.ts
+++ b/examples/write.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview write / table / dir 示例
+ * @description 演示 logger.write / logger.table / logger.dir 的用法
+ */
+
+import { configure, logger, setLogLevel } from '../src';
+
+configure();
+setLogLevel('debug');
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+logger.scope({ namespace: 'write' }, async log => {
+  log.write('首先输出内容，等 3 秒后整行输出 done');
+
+  await sleep(3000);
+
+  log.write('done（结束改写，需要自行在结尾进行换行符拼接）\n');
+
+  log.info('finished', { a: 1, b: '2' });
+});

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "example:advanced": "ts-node ./examples/advanced.ts",
     "example:config": "ts-node ./examples/configuration.ts",
     "example:color": "ts-node ./examples/color.ts",
-    "example:real": "ts-node ./examples/real-world.ts"
+    "example:real": "ts-node ./examples/real-world.ts",
+    "example:td": "ts-node ./examples/table-dir.ts",
+    "example:write": "ts-node ./examples/write.ts"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/logger/console.ts
+++ b/src/logger/console.ts
@@ -258,26 +258,26 @@ export const LoggerFactoryOfConsole: CoreLoggerFactory<LoggerContext> = () => {
      *
      * 该方法固定以 `info` 级别输出（用于保持与 `logger.write` 的“无级别/直写”语义兼容）。
      */
-    write: (context, ...messages) => {
+    write: (context, message) => {
       if (!isNodeEnvironment()) {
-        coreLogger.print({ level: 'info', context }, ...messages);
+        coreLogger.print({ level: 'info', context }, message);
         return;
       }
 
       const { config, ...rest } = context;
 
       if (config.format === 'json') {
-        const chunks = jsonStringifySafe({ level: 'info', ...rest, messages });
+        const chunks = jsonStringifySafe({ level: 'info', ...rest, message });
 
-        process.stdout.write(`${chunks}\n`);
+        process.stdout.write(`\r\x1b[2K${chunks}`);
       }
 
       if (config.format === 'text') {
-        const chunks = buildChunksForText(context, 'info', messages);
-        process.stdout.write(`${chunks.join(' ')}\n`);
+        const chunks = buildChunksForText(context, 'info', [message]);
+        process.stdout.write(`\r\x1b[2K${chunks.join(' ')}`);
       }
 
-      if (config.hook) config.hook('info', context, ...messages);
+      if (config.hook) config.hook('info', context, message);
     },
     /**
      * 打印日志的核心方法

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -209,7 +209,7 @@ const createLoggerWrap = (
 
     // 调用核心日志记录器输出日志
     if (level === 'none') {
-      coreLogger.write(context, ...msg);
+      coreLogger.write(context, msg[0] as string);
     } else {
       coreLogger.print({ level, context }, ...msg);
     }
@@ -257,7 +257,7 @@ const createLoggerWrap = (
      *
      * 注意：`write` 仍会执行过滤器（`config.filter`）与 hook（若核心实现支持）。
      */
-    write: (...msg) => print('none', ...msg),
+    write: msg => print('none', msg),
     /**
      * 创建一个新的子日志记录器
      * @param {LoggerSubContext<LoggerContext>} ctx - 子上下文配置

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,7 +191,7 @@ interface WithCluster<CTX extends LoggerContext> {
    * - 默认控制台实现（Node.js）会写入一行并追加换行；浏览器环境会降级为 `info` 打印。
    * @param ...msg 日志消息数组
    */
-  write: LogFunction;
+  write: (message: string) => unknown;
   /**
    * 创建一个新的子日志记录器
    * @param context 子上下文配置
@@ -276,9 +276,9 @@ export interface CoreLogger<CTX extends LoggerContext> {
    *
    * 注意：是否追加换行由具体实现决定；接口层不做强约束。
    * @param context 日志上下文
-   * @param ...msg 日志消息数组
+   * @param msg 日志消息
    */
-  write: (context: CTX, ...msg: Array<unknown>) => unknown;
+  write: (context: CTX, msg: string) => unknown;
   /**
    * 打印日志的核心方法
    * @param env 包含日志级别和上下文的环境对象

--- a/tests/logger/write.test.ts
+++ b/tests/logger/write.test.ts
@@ -56,12 +56,15 @@ describe('coreLogger.write', () => {
       .spyOn(console, 'info')
       .mockImplementation(() => {});
 
-    coreLogger.write(mockContext, 'hello', 123);
+    coreLogger.write(mockContext, 'hello');
 
     expect(stdoutSpy).toHaveBeenCalledOnce();
     const arg = stdoutSpy.mock.calls[0]?.[0];
     expect(typeof arg).toBe('string');
-    expect((arg as string).endsWith('\n')).toBe(true);
+
+    // write() 在 Node 环境下使用“清行 + 回车”写入（不保证以换行结尾）
+    expect((arg as string).startsWith('\r\u001b[2K')).toBe(true);
+    expect(arg as string).toContain('hello');
 
     // Node 分支不应降级走 console.info
     expect(consoleInfoSpy).not.toHaveBeenCalled();
@@ -87,7 +90,7 @@ describe('coreLogger.write', () => {
       .spyOn(console, 'info')
       .mockImplementation(() => {});
 
-    coreLogger.write(mockContext, 'hello', { a: 1 });
+    coreLogger.write(mockContext, 'hello');
 
     expect(consoleInfoSpy).toHaveBeenCalledOnce();
     expect(stdoutSpy).not.toHaveBeenCalled();
@@ -115,7 +118,7 @@ describe('logger.write', () => {
       createCoreLogger: () => fakeCoreLogger
     });
 
-    logger.write('hello', 1, { a: 1 });
+    logger.write('hello');
 
     expect(writeSpy).toHaveBeenCalledOnce();
     expect(printSpy).not.toHaveBeenCalled();
@@ -135,7 +138,7 @@ describe('logger.write', () => {
     const { configure, logger } = await import('../../src/logger');
     configure();
 
-    logger.write('hello', { a: 1 });
+    logger.write('hello');
 
     expect(infoSpy).toHaveBeenCalledOnce();
     expect(stdoutSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
- Introduced two new example scripts: `table-dir.ts` and `write.ts` to demonstrate logger functionalities.
- Updated the `write` method signature in the logger interface to accept a single message string instead of a message array for improved clarity and consistency.
- Adjusted related implementations in the console logger to align with the new method signature.