### PR TITLE
feat: add logger proxy support in configure

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@
 
 node_modules
 dist/
+
+pnpm-lock.yaml

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,13 @@ export default [
   ...jshowConfig.node,
   ...prettierConfigs,
   {
-    ignores: ['dist', 'node_modules', 'build', 'coverage']
+    ignores: [
+      '**/dist/*',
+      '**/node_modules/*',
+      '**/build/*',
+      '**/coverage/*',
+      'pnpm-lock.yaml'
+    ]
   },
   {
     // 为 examples 目录中的 CommonJS 文件添加特殊配置

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -6,15 +6,17 @@
 
 import { ColorIdxDefault, wrapAnsiIndex } from '../color';
 import {
+  type ConfigureOptions,
   type CoreLogger,
-  type CoreLoggerFactory,
   type Logger,
   LOGGER_APPEND_CONFIG,
   type LoggerConfig,
   type LoggerContext,
+  type LoggerProxyHandler,
   type LoggerSubContext,
   type LogLevel,
-  LogLevels
+  LogLevels,
+  type LogMeta
 } from '../types';
 
 import { LoggerFactoryOfConsole } from './console';
@@ -401,13 +403,47 @@ const createLoggerWrap = (
  * logger.info('Hello World');
  * logger.error('Something went wrong');
  */
-export const logger = createLoggerWrap({
+const realLogger = createLoggerWrap({
   config: {
     format: 'text',
     enableNamespacePrefix: true,
     enableNamespacePrefixColors: true,
     appendTagsForTextPrint: true,
     appendExtraForTextPrint: true
+  }
+});
+
+let proxyLogger: Logger | null = null;
+
+const createLoggerProxy = (
+  logger: Logger,
+  handle: LoggerProxyHandler,
+  meta: LogMeta = {}
+): Logger => {
+  return new Proxy<Logger>(logger, {
+    get(target, key: keyof Logger, self) {
+      if (LogLevels.includes(key as LogLevel)) {
+        return handle(target, key, self, meta);
+      }
+
+      if (key === 'fork') {
+        return ctx => createLoggerProxy(target, handle, { ...meta, ...ctx });
+      }
+
+      if (key === 'scope') {
+        return (ctx, cb) =>
+          cb(createLoggerProxy(target, handle, { ...meta, ...ctx }));
+      }
+
+      return target[key];
+    }
+  });
+};
+
+export const logger = new Proxy<Logger>(realLogger, {
+  get(_, key) {
+    if (!proxyLogger) return realLogger[key];
+    return proxyLogger[key];
   }
 });
 
@@ -429,16 +465,18 @@ let configureFucntionCallCount = 0;
  *   enableNamespacePrefix: false
  * });
  */
-export function configure({
+export function configure<T extends LoggerContext = LoggerContext>({
   createCoreLogger = LoggerFactoryOfConsole,
+  processLoggerProxy,
   config = {}
-}: {
-  createCoreLogger?: CoreLoggerFactory<LoggerContext>;
-  config?: Partial<LoggerConfig>;
-} = {}): void {
+}: ConfigureOptions<T> = {}): void {
   if (configureFucntionCallCount++) {
     throw new Error('Logger has been configured');
   }
+
+  proxyLogger = processLoggerProxy
+    ? createLoggerProxy(realLogger, processLoggerProxy)
+    : null;
 
   coreLogger = createCoreLogger();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * @fileoverview 日志记录器的类型定义
  * @module types
@@ -11,27 +12,6 @@
 export interface LogMeta {
   [key: string]: unknown;
 }
-
-/**
- * 错误元数据接口
- * @interface ErrorMeta
- * @extends {LogMeta}
- * @template T 标签类型，默认为字符串键值对对象
- * @description 扩展了 LogMeta，用于错误日志的特殊元数据
- */
-export interface ErrorMeta<T = { [key: string]: string }> extends LogMeta {
-  /** 可选的标签集合 */
-  setTags?: T;
-}
-
-/**
- * 错误类对象类型
- * @typedef {Error | { stack: string; message: string; name: string }} ErrorLiked
- * @description 表示类似 Error 的对象，包含 stack、message 和 name 属性
- */
-export type ErrorLiked =
-  | Error
-  | { stack: string; message: string; name: string };
 
 /**
  * 日志级别常量数组
@@ -275,7 +255,7 @@ export interface Logger<CTX extends LoggerContext = LoggerContext>
  * @template CTX 日志上下文类型
  * @description 定义日志输出的核心接口，由具体的实现类来实现
  */
-export interface CoreLogger<CTX extends LoggerContext> {
+export interface CoreLogger<CTX extends LoggerContext = LoggerContext> {
   /**
    * 写入日志（更贴近“直写/流式”语义）。
    *
@@ -301,5 +281,23 @@ export interface CoreLogger<CTX extends LoggerContext> {
  * @template CTX 日志上下文类型
  * @description 用于创建核心日志记录器实例的工厂函数
  */
-export type CoreLoggerFactory<CTX extends LoggerContext> =
+export type CoreLoggerFactory<CTX extends LoggerContext = LoggerContext> =
   () => CoreLogger<CTX>;
+
+/**
+ * 日志记录器代理处理函数类型
+ * @typedef {(logger: Logger, key: keyof Logger, self: any, meta?: LogMeta) => any} LoggerProxyHandler
+ * @description 用于处理日志记录器代理的函数，返回值为 any
+ */
+export type LoggerProxyHandler<CTX extends LoggerContext = LoggerContext> = (
+  logger: Logger<CTX>,
+  key: keyof Logger,
+  self: any,
+  meta?: LogMeta
+) => any;
+
+export interface ConfigureOptions<CTX extends LoggerContext = LoggerContext> {
+  createCoreLogger?: CoreLoggerFactory<CTX>;
+  processLoggerProxy?: LoggerProxyHandler<CTX>;
+  config?: Partial<LoggerConfig>;
+}


### PR DESCRIPTION
- Add processLoggerProxy to intercept log level calls with fork/scope meta
- Wrap exported logger in proxy so configure can replace the active instance
- Ignore pnpm-lock.yaml in eslint and prettier configs